### PR TITLE
chore(security): pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '16.8'
           check-latest: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package.json') }}
@@ -36,21 +36,20 @@ jobs:
           npm run build:types
       - name: Test
         run: npm t -- --coverage --colors
-      - uses: codecov/codecov-action@v2
-
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
   website:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '16.x'
           check-latest: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package.json') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: node_modules/.cache
           key: build-${{ hashFiles('package.json') }}


### PR DESCRIPTION
## Summary

This PR pins all third-party GitHub Actions `uses:` references to their full commit SHAs to mitigate supply chain attacks.

Each pinned line retains a comment showing the original version tag for human readability, e.g.:
```yaml
uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
```

### Why

Using version tags (e.g. `@v4`) instead of full commit SHAs means your workflow can silently pull in changed code if a tag is moved or hijacked. Pinning to a SHA guarantees you always run the exact same code.

### References

- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
- Internal enforcement strategy: `Volue/platform-workflow-library/docs/security/github-actions-sha-enforcement.md`

---
*This PR was created automatically by `scripts/create-sha-pinning-prs.sh` from `Volue/platform-workflow-library`.*